### PR TITLE
fix "component properties" subtitle in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ To run this example yourself, you need to do the following:
 
 <BR>
 <BR>
+
 ### Component properties
 
 | Prop | Type | Description |


### PR DESCRIPTION
This fixes the display of the subtitle, and allows the anchor at the top of the page to work :+1: